### PR TITLE
Return false if structure check is called with an array

### DIFF
--- a/src/structure.ts
+++ b/src/structure.ts
@@ -98,7 +98,7 @@ function isStructure(structure: { [name: string]: Predicate | Function }, value?
         setDescription(
             function isStructurePredicate(value: Object) {
                 const match = (key: string) => structure[key].apply(this, [(<any>value)[key]].concat(extraArgs));
-                return isObject(value) && keys.every(match);
+                return isObject(value) && !Array.isArray(value) && keys.every(match);
             },
             'an object with properties: ' + structureDescription
         )

--- a/test/structureTest.ts
+++ b/test/structureTest.ts
@@ -3,6 +3,8 @@ import {assert} from 'chai';
 import isString from '../src/string';
 import * as sinon from 'sinon';
 import {getDescription} from "../src/utils/description";
+import isUndefinedOr from '../src/undefinedOr';
+import isUndefined from '../src/undefined';
 
 describe('structure', function () {
     const STRUCTURE = {
@@ -156,5 +158,14 @@ describe('structure', function () {
         assert.isTrue(structure(Function)(exampleObject(noop)));
         assert.isTrue(structure(Date)(exampleObject(new Date())));
         assert.isTrue(structure(Array)(exampleObject([])));
+    });
+
+    it('array is not a valid argument for a structure check', () => {
+        function structure(func: Function) {
+            return isValidStructure({key: func});
+        }
+
+        assert.isFalse(structure(isUndefinedOr(isString))([]));
+        assert.isFalse(structure(isUndefined)([]));
     });
 });


### PR DESCRIPTION
Currently if you make a structure where all values of an object are supposed to be undefined[Or], the check will return `true` if you supply it with an Array
example:
```
const structureCheck = is.structure({ key: is.undefinedOr(is.string) });
console.log(structureCheck([]));
```
the console.log will write out `true`